### PR TITLE
Fix the uninitialized buffer in OpenPGPApplet.

### DIFF
--- a/src/pro/javacard/applets/OpenPGPApplet.java
+++ b/src/pro/javacard/applets/OpenPGPApplet.java
@@ -159,6 +159,7 @@ public class OpenPGPApplet extends Applet implements ExtendedLength {
 	public OpenPGPApplet() {
 		// Create temporary arrays
 		tmp = JCSystem.makeTransientByteArray(BUFFER_MAX_LENGTH, JCSystem.CLEAR_ON_DESELECT);
+		buffer = JCSystem.makeTransientByteArray(BUFFER_MAX_LENGTH,JCSystem.CLEAR_ON_DESELECT);
 		pw1_modes = JCSystem.makeTransientBooleanArray((short) 2, JCSystem.CLEAR_ON_DESELECT);
 
 		// Initialize PW1 with default password


### PR DESCRIPTION
'buffer' variable was not initialized resulting in 6F00 SW when applet got selected. This fixes that issue.
Signed-off-by: Pierre-David Oriol ouaibe@gmail.com
